### PR TITLE
Fix bmp-detector typo in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ bpm-detector --detect-key *.wav *.mp3
 bpm-detector --progress --detect-key your_audio_file.wav
 
 # Parallel processing (NEW!)
-bmp-detector --comprehensive your_audio_file.wav  # Auto-parallel enabled by default
+bpm-detector --comprehensive your_audio_file.wav  # Auto-parallel enabled by default
 bpm-detector --comprehensive --max-workers 4 your_audio_file.wav  # Manual worker count
 bpm-detector --comprehensive --no-parallel your_audio_file.wav  # Disable parallel processing
 bpm-detector --show-system-info  # Show system capabilities and parallel configuration

--- a/README_ja.md
+++ b/README_ja.md
@@ -144,7 +144,7 @@ rye sync
 bpm-detector your_audio_file.wav
 
 # キー検出も含める場合
-bmp-detector --detect-key your_audio_file.wav
+bpm-detector --detect-key your_audio_file.wav
 
 # 複数ファイルの処理
 bpm-detector --detect-key *.wav *.mp3


### PR DESCRIPTION
## Summary
- replace `bmp-detector` with `bpm-detector` in docs

## Testing
- `PYENV_VERSION=3.12.10 pytest -q` *(fails: ModuleNotFoundError for psutil, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_683ad06f2cec83278ee7779fee3c0a25