### PR TITLE
Fix flake8 F824 warnings

### DIFF
--- a/src/bpm_detector/cli.py
+++ b/src/bpm_detector/cli.py
@@ -33,7 +33,7 @@ interrupted = False
 
 def signal_handler(signum, frame):
     """Handle Ctrl+C gracefully."""
-    global interrupted, current_analyzer
+    global interrupted
     interrupted = True
     
     print(f"\n{Fore.YELLOW}⚠️  Interrupted by user. Cleaning up...{Style.RESET_ALL}")
@@ -277,9 +277,8 @@ def analyze_file_with_progress(path: str, analyzer, args: argparse.Namespace) ->
         progress_display = None
         if args.progress:
             progress_display = create_progress_display(detailed=args.detailed_progress)
-        
+
         def smart_progress_callback(progress: float, message: str = ""):
-            global interrupted
             if interrupted:
                 raise KeyboardInterrupt("Analysis interrupted by user")
             
@@ -441,7 +440,6 @@ def main() -> None:
         if hasattr(analyzer, 'analyze_file') and hasattr(analyzer, '_parallel_config'):
             try:
                 def multi_progress_callback(progress: float, message: str = ""):
-                    global interrupted
                     if interrupted:
                         raise KeyboardInterrupt("Analysis interrupted by user")
                     


### PR DESCRIPTION
## Summary
- remove unused `global` declarations in `cli.py`

## Testing
- `pip install flake8` *(fails: externally-managed-environment)*
- `flake8 src/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics` *(fails: command not found)*
- `pytest -q` *(fails due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683ad23519d08327b384909cafa0086b