### PR TITLE
Update progress flag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ bpm-detector --detect-key your_audio_file.wav
 # Multiple files
 bpm-detector --detect-key *.wav *.mp3
 
-# Show progress bar
-bpm-detector --progress --detect-key your_audio_file.wav
+# Suppress progress output
+bpm-detector --quiet --detect-key your_audio_file.wav
 
 # Parallel processing (NEW!)
 bpm-detector --comprehensive your_audio_file.wav  # Auto-parallel enabled by default
@@ -308,7 +308,7 @@ docker run --rm -v $(pwd):/workspace bpm-detector --help
 #### Basic Options
 - `--detect-key`: Enable key detection
 - `--comprehensive`: Enable comprehensive music analysis
-- `--progress`: Show progress bar
+- `--quiet`: Suppress progress output
 - `--sr SR`: Sample rate (default: 22050)
 - `--hop HOP`: Hop length (default: 128)
 - `--min_bpm MIN_BPM`: Minimum BPM (default: 40.0)

--- a/README_ja.md
+++ b/README_ja.md
@@ -149,8 +149,8 @@ bpm-detector --detect-key your_audio_file.wav
 # 複数ファイルの処理
 bpm-detector --detect-key *.wav *.mp3
 
-# プログレスバーを表示
-bpm-detector --progress --detect-key your_audio_file.wav
+# 進捗表示を抑制
+bpm-detector --quiet --detect-key your_audio_file.wav
 
 # 並列処理（新機能！）
 bpm-detector --comprehensive your_audio_file.wav  # 自動並列処理がデフォルトで有効
@@ -308,7 +308,7 @@ docker run --rm -v $(pwd):/workspace bpm-detector --help
 #### 基本オプション
 - `--detect-key`: キー検出を有効にする
 - `--comprehensive`: 包括的楽曲解析を有効にする
-- `--progress`: プログレスバーを表示
+- `--quiet`: 進捗表示を抑制
 - `--sr SR`: サンプリングレート（デフォルト: 22050）
 - `--hop HOP`: ホップ長（デフォルト: 128）
 - `--min_bpm MIN_BPM`: 最小BPM（デフォルト: 40.0）


### PR DESCRIPTION
## Summary
- remove obsolete `--progress` flag references from README and README_ja
- document `--quiet` to disable progress output
- update command examples

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_683ad2cc142083279fa219a4c87ca49e